### PR TITLE
Readonly access removed for dummy event

### DIFF
--- a/definitions/private-law/json/AuthorisationCaseEvent/ReadOnlyUserAuth/AuthorisationCaseEvent.json
+++ b/definitions/private-law/json/AuthorisationCaseEvent/ReadOnlyUserAuth/AuthorisationCaseEvent.json
@@ -709,13 +709,6 @@
   {
     "LiveFrom": "25/06/2023",
     "CaseTypeID": "PRLAPPS",
-    "CaseEventID": "testingSupportDummyCase",
-    "UserRole": "caseworker-privatelaw-readonly",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "25/06/2023",
-    "CaseTypeID": "PRLAPPS",
     "CaseEventID": "courtnav-document-upload",
     "UserRole": "caseworker-privatelaw-readonly",
     "CRUD": "R"


### PR DESCRIPTION
### JIRA link (if applicable) ###
NA


### Change description ###
PROD ccd import is failing due to Dummy event read only auth which is not needed


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```