### PR TITLE
PRL-5365/serve_order_to_unrepresented_applicant

### DIFF
--- a/env.json
+++ b/env.json
@@ -5,9 +5,9 @@
     "aacUrl": "http://localhost:4454"
   },
   "preview": {
-    "cosUrl": "http://prl-cos-pr-2061-java",
-    "ccdUrl": "http://prl-ccd-definitions-pr-1903-ccd-data-store-api",
-    "aacUrl": "http://prl-ccd-definitions-pr-1903-aac-manage-case-assignment"
+    "cosUrl": "http://prl-cos-pr-test-java",
+    "ccdUrl": "http://prl-ccd-definitions-pr-test-ccd-data-store-api",
+    "aacUrl": "http://prl-ccd-definitions-pr-test-aac-manage-case-assignment"
   },
   "demo": {
     "cosUrl": "http://prl-cos-demo.service.core-compute-demo.internal",

--- a/env.json
+++ b/env.json
@@ -5,9 +5,9 @@
     "aacUrl": "http://localhost:4454"
   },
   "preview": {
-    "cosUrl": "http://prl-cos-pr-test-java",
-    "ccdUrl": "http://prl-ccd-definitions-pr-test-ccd-data-store-api",
-    "aacUrl": "http://prl-ccd-definitions-pr-test-aac-manage-case-assignment"
+    "cosUrl": "http://prl-cos-pr-2259-java",
+    "ccdUrl": "http://prl-ccd-definitions-pr-2056-ccd-data-store-api",
+    "aacUrl": "http://prl-ccd-definitions-pr-2056-aac-manage-case-assignment"
   },
   "demo": {
     "cosUrl": "http://prl-cos-demo.service.core-compute-demo.internal",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRL-5365

### Change description ###

When an order is served to an unrepresneted applicant, the system does not allow for the order to be sent through the post. This change will implement a feature allowing an unrepresnted applicant to be served through the post.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```