### PR TITLE
SNI-6902: Show respondent solicitor name on response statement of truth

### DIFF
--- a/definitions/private-law/json/AuthorisationCaseField/RespondentSolicitor/Submit/AuthorisationCaseField.json
+++ b/definitions/private-law/json/AuthorisationCaseField/RespondentSolicitor/Submit/AuthorisationCaseField.json
@@ -285,5 +285,35 @@
         "CRUD": "R"
       }
     ]
+  },
+  {
+    "LiveFrom": "02/12/2021",
+    "CaseTypeID": "PRLAPPS",
+    "CaseFieldID": "respondentSolicitorName",
+    "AccessControl": [
+      {
+        "UserRoles": [
+          "[C100RESPONDENTSOLICITOR1]",
+          "[C100RESPONDENTSOLICITOR2]",
+          "[C100RESPONDENTSOLICITOR3]",
+          "[C100RESPONDENTSOLICITOR4]",
+          "[C100RESPONDENTSOLICITOR5]",
+          "caseworker-privatelaw-systemupdate"
+        ],
+        "CRUD": "CRU"
+      },
+      {
+        "UserRoles": [
+          "[APPLICANTSOLICITOR]",
+          "[CREATOR]",
+          "citizen",
+          "caseworker-privatelaw-courtadmin",
+          "caseworker-privatelaw-judge",
+          "caseworker-privatelaw-la",
+          "caseworker-privatelaw-superuser"
+        ],
+        "CRUD": "R"
+      }
+    ]
   }
 ]

--- a/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/A/CaseEventToFields.json
+++ b/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/A/CaseEventToFields.json
@@ -33,7 +33,7 @@
     "LiveFrom": "02/12/2021",
     "CaseTypeID": "PRLAPPS",
     "CaseEventID": "c100ResSolSubmitA",
-    "CaseFieldID": "solicitorName",
+    "CaseFieldID": "respondentSolicitorName",
     "PageFieldDisplayOrder": 3,
     "DisplayContext": "READONLY",
     "PageID": 2,

--- a/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/B/CaseEventToFields.json
+++ b/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/B/CaseEventToFields.json
@@ -33,7 +33,7 @@
     "LiveFrom": "02/12/2021",
     "CaseTypeID": "PRLAPPS",
     "CaseEventID": "c100ResSolSubmitB",
-    "CaseFieldID": "solicitorName",
+    "CaseFieldID": "respondentSolicitorName",
     "PageFieldDisplayOrder": 3,
     "DisplayContext": "READONLY",
     "PageID": 2,

--- a/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/C/CaseEventToFields.json
+++ b/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/C/CaseEventToFields.json
@@ -33,7 +33,7 @@
     "LiveFrom": "02/12/2021",
     "CaseTypeID": "PRLAPPS",
     "CaseEventID": "c100ResSolSubmitC",
-    "CaseFieldID": "solicitorName",
+    "CaseFieldID": "respondentSolicitorName",
     "PageFieldDisplayOrder": 3,
     "DisplayContext": "READONLY",
     "PageID": 2,

--- a/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/D/CaseEventToFields.json
+++ b/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/D/CaseEventToFields.json
@@ -33,7 +33,7 @@
     "LiveFrom": "02/12/2021",
     "CaseTypeID": "PRLAPPS",
     "CaseEventID": "c100ResSolSubmitD",
-    "CaseFieldID": "solicitorName",
+    "CaseFieldID": "respondentSolicitorName",
     "PageFieldDisplayOrder": 3,
     "DisplayContext": "READONLY",
     "PageID": 2,

--- a/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/E/CaseEventToFields.json
+++ b/definitions/private-law/json/CaseEventToFields/RespondentSolicitor/Submit/E/CaseEventToFields.json
@@ -33,7 +33,7 @@
     "LiveFrom": "02/12/2021",
     "CaseTypeID": "PRLAPPS",
     "CaseEventID": "c100ResSolSubmitE",
-    "CaseFieldID": "solicitorName",
+    "CaseFieldID": "respondentSolicitorName",
     "PageFieldDisplayOrder": 3,
     "DisplayContext": "READONLY",
     "PageID": 2,

--- a/definitions/private-law/json/CaseField/RespondentSolicitor/Submit/CaseField.json
+++ b/definitions/private-law/json/CaseField/RespondentSolicitor/Submit/CaseField.json
@@ -97,5 +97,14 @@
     "FieldType": "Document",
     "SecurityClassification": "Public",
     "Searchable": "N"
+  },
+  {
+    "LiveFrom": "29/11/2024",
+    "CaseTypeID": "PRLAPPS",
+    "ID": "solicitorName",
+    "Label": " ",
+    "FieldType": "Text",
+    "SecurityClassification": "Public",
+    "Searchable": "N"
   }
 ]

--- a/definitions/private-law/json/CaseField/RespondentSolicitor/Submit/CaseField.json
+++ b/definitions/private-law/json/CaseField/RespondentSolicitor/Submit/CaseField.json
@@ -101,7 +101,7 @@
   {
     "LiveFrom": "29/11/2024",
     "CaseTypeID": "PRLAPPS",
-    "ID": "solicitorName",
+    "ID": "respondentSolicitorName",
     "Label": " ",
     "FieldType": "Text",
     "SecurityClassification": "Public",

--- a/definitions/private-law/json/CaseField/RespondentSolicitor/Submit/CaseField.json
+++ b/definitions/private-law/json/CaseField/RespondentSolicitor/Submit/CaseField.json
@@ -12,7 +12,7 @@
     "LiveFrom": "02/12/2021",
     "CaseTypeID": "PRLAPPS",
     "ID": "c100ResSolSubmitAndPayAgreeSignStmtLabel",
-    "Label": "The respondent believes that the facts stated in this form and any continuation sheets are true. ${solicitorName}  is authorised by the respondent to sign this statement. ",
+    "Label": "The respondent believes that the facts stated in this form and any continuation sheets are true. ${respondentSolicitorName}  is authorised by the respondent to sign this statement. ",
     "FieldType": "Label",
     "SecurityClassification": "Public"
   },

--- a/env.json
+++ b/env.json
@@ -5,9 +5,9 @@
     "aacUrl": "http://localhost:4454"
   },
   "preview": {
-    "cosUrl": "http://prl-cos-pr-2869-java",
-    "ccdUrl": "http://prl-ccd-definitions-pr-2498-ccd-data-store-api",
-    "aacUrl": "http://prl-ccd-definitions-pr-2498-aac-manage-case-assignment"
+    "cosUrl": "http://prl-cos-pr-2903-java",
+    "ccdUrl": "http://prl-ccd-definitions-pr-2532-ccd-data-store-api",
+    "aacUrl": "http://prl-ccd-definitions-pr-2532-aac-manage-case-assignment"
   },
   "demo": {
     "cosUrl": "http://prl-cos-demo.service.core-compute-demo.internal",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SNI-6902


### Change description ###
Fixes issue where applicant solicitor name shows instead of respondent solicitor's for the statement of truth when respondent solicitor is submitting the response.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```