### PR TITLE
PRL-6786 - Make "Hearing outcome" text box optional for FL404B orders

### DIFF
--- a/definitions/private-law/json/CaseEventToComplexTypes/DraftAnOrder/FL404/CaseEventToComplexTypes.json
+++ b/definitions/private-law/json/CaseEventToComplexTypes/DraftAnOrder/FL404/CaseEventToComplexTypes.json
@@ -352,7 +352,7 @@
     "ListElementCode": "fl404bHearingOutcome",
     "EventElementLabel": "Hearing outcome",
     "FieldDisplayOrder": "32",
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "OPTIONAL",
     "FieldShowCondition": "createSelectOrderOptions=\"blank\" OR createSelectOrderOptions=\"amendDischargedVaried\""
   },
   {

--- a/definitions/private-law/json/CaseEventToComplexTypes/DraftOrderAdmin/FL404/CaseEventToComplexTypes.json
+++ b/definitions/private-law/json/CaseEventToComplexTypes/DraftOrderAdmin/FL404/CaseEventToComplexTypes.json
@@ -358,7 +358,7 @@
     "ListElementCode": "fl404bHearingOutcome",
     "EventElementLabel": "Hearing outcome",
     "FieldDisplayOrder": "32",
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "OPTIONAL",
     "FieldShowCondition": "orderType=\"blank\" OR orderType=\"amendDischargedVaried\""
   },
   {

--- a/definitions/private-law/json/CaseEventToComplexTypes/EditAndApprove/FL404/CaseEventToComplexTypes.json
+++ b/definitions/private-law/json/CaseEventToComplexTypes/EditAndApprove/FL404/CaseEventToComplexTypes.json
@@ -358,7 +358,7 @@
     "ListElementCode": "fl404bHearingOutcome",
     "EventElementLabel": "Hearing outcome",
     "FieldDisplayOrder": "32",
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "OPTIONAL",
     "FieldShowCondition": "orderType=\"blank\" OR orderType=\"amendDischargedVaried\""
   },
   {

--- a/definitions/private-law/json/CaseEventToComplexTypes/EditReturnedOrder/FL404/CaseEventToComplexTypes.json
+++ b/definitions/private-law/json/CaseEventToComplexTypes/EditReturnedOrder/FL404/CaseEventToComplexTypes.json
@@ -358,7 +358,7 @@
     "ListElementCode": "fl404bHearingOutcome",
     "EventElementLabel": "Hearing outcome",
     "FieldDisplayOrder": "32",
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "OPTIONAL",
     "FieldShowCondition": "orderType=\"blank\" OR orderType=\"amendDischargedVaried\""
   },
   {

--- a/definitions/private-law/json/CaseEventToComplexTypes/ManageOrders/FL404/CaseEventToComplexTypes.json
+++ b/definitions/private-law/json/CaseEventToComplexTypes/ManageOrders/FL404/CaseEventToComplexTypes.json
@@ -270,7 +270,7 @@
     "ListElementCode": "fl404bHearingOutcome",
     "EventElementLabel": "Hearing outcome",
     "FieldDisplayOrder": "37",
-    "DisplayContext": "MANDATORY",
+    "DisplayContext": "OPTIONAL",
     "FieldShowCondition": "createSelectOrderOptions=\"blank\" OR createSelectOrderOptions=\"amendDischargedVaried\""
   },
   {

--- a/definitions/private-law/json/CaseEventToComplexTypes/ManageOrders/FL404B/CaseEventToComplexTypes.json
+++ b/definitions/private-law/json/CaseEventToComplexTypes/ManageOrders/FL404B/CaseEventToComplexTypes.json
@@ -247,6 +247,6 @@
     "ListElementCode": "fl404bHearingOutcome",
     "EventElementLabel": "Hearing outcome",
     "FieldDisplayOrder": "29",
-    "DisplayContext": "MANDATORY"
+    "DisplayContext": "OPTIONAL"
   }
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRL-6786


### Change description ###
Make Hearing outcome text box optional for FL404B orders blank, amend discharged or varied orders


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```