### PR TITLE
Update path-to-regexp to a non-vulnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "rimraf": "^5.0.0",
     "cookie": "^1.0.2",
     "cross-spawn": "^7.0.6",
-    "path-to-regexp": "^0.2.0"
+    "path-to-regexp": "^1.0.0"
   },
   "packageManager": "yarn@4.9.0",
   "overrides": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6575,6 +6575,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isarray@npm:0.0.1":
+  version: 0.0.1
+  resolution: "isarray@npm:0.0.1"
+  checksum: 10c0/ed1e62da617f71fe348907c71743b5ed550448b455f8d269f89a7c7ddb8ae6e962de3dab6a74a237b06f5eb7f6ece7a45ada8ce96d87fe972926530f91ae3311
+  languageName: node
+  linkType: hard
+
 "isarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "isarray@npm:1.0.0"
@@ -9121,10 +9128,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^0.2.0":
-  version: 0.2.5
-  resolution: "path-to-regexp@npm:0.2.5"
-  checksum: 10c0/947ffdd583390408a4814dcb921226fba363110a8245d22bd11c2bb1db323ad76b2e879f6dadc02bcf8c9c925b1556d5405c01a466dd28a93d84af5f62c51b79
+"path-to-regexp@npm:^1.0.0":
+  version: 1.9.0
+  resolution: "path-to-regexp@npm:1.9.0"
+  dependencies:
+    isarray: "npm:0.0.1"
+  checksum: 10c0/de9ddb01b84d9c2c8e2bed18630d8d039e2d6f60a6538595750fa08c7a6482512257464c8da50616f266ab2cdd2428387e85f3b089e4c3f25d0c537e898a0751
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Change description ###

- Upgraded the path-to-regexp dependency to next major version to remove vulnerability flagged in the pipeline
- path-to-regexp is a transitive dependency coming from the express@npm:4.21.2 package so I decided to upgrade path-to-regexp rather than express which would've been a bigger change

See vulnerability below:
```
Unsuppressed vulnerabilities found:
08:11:37  ├─ path-to-regexp: 0.2.5
08:11:37  │  ├─ ID: 1101849
08:11:37  │  ├─ Issue: 
08:11:37  │  ├─ URL: 
08:11:37  │  ├─ Severity: high
08:11:37  │  ├─ Vulnerable Versions: 
08:11:37  │  ├─ Patched Versions: 
08:11:37  │  ├─ Via: express@npm:4.21.2
08:11:37  │  └─ Recommendation: Upgrade to undefined
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```