### PR TITLE
FPVTL-917: Add same permissions for judge/la as courtadmin to new field

### DIFF
--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -33,7 +33,7 @@ xui-webapp:
       HEALTH_CCD_DATA_API: http://${SERVICE_NAME}-ccd-data-store-api/health
       HEALTH_TERMS_AND_CONDITIONS_API: https://xui-terms-and-conditions-${SERVICE_FQDN}
       SERVICES_CCD_COMPONENT_API: http://${SERVICE_NAME}-ccd-api-gw
-      SERVICES_CCD_DATA_STORE_API: https://ccd-data-store-api-prl-ccd-definitions-pr-${CHANGE_ID}.preview.platform.hmcts.net
+      SERVICES_CCD_DATA_STORE_API: https://ccd-data-store-api-prl-ccd-definitions-pr-2792.preview.platform.hmcts.net
       SERVICES_CCD_CASE_ASSIGNMENT_API: http://${SERVICE_NAME}-aac-manage-case-assignment
       SERVICES_TERMS_AND_CONDITIONS: https://xui-terms-and-conditions-${SERVICE_FQDN}
       JURISDICTIONS: PRIVATELAW

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -33,7 +33,7 @@ xui-webapp:
       HEALTH_CCD_DATA_API: http://${SERVICE_NAME}-ccd-data-store-api/health
       HEALTH_TERMS_AND_CONDITIONS_API: https://xui-terms-and-conditions-${SERVICE_FQDN}
       SERVICES_CCD_COMPONENT_API: http://${SERVICE_NAME}-ccd-api-gw
-      SERVICES_CCD_DATA_STORE_API: https://ccd-data-store-api-prl-ccd-definitions-pr-2773.preview.platform.hmcts.net
+      SERVICES_CCD_DATA_STORE_API: https://ccd-data-store-api-prl-ccd-definitions-pr-${CHANGE_ID}.preview.platform.hmcts.net
       SERVICES_CCD_CASE_ASSIGNMENT_API: http://${SERVICE_NAME}-aac-manage-case-assignment
       SERVICES_TERMS_AND_CONDITIONS: https://xui-terms-and-conditions-${SERVICE_FQDN}
       JURISDICTIONS: PRIVATELAW

--- a/definitions/private-law/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/private-law/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -17143,6 +17143,8 @@
     "AccessControl": [
       {
         "UserRoles": [
+          "caseworker-privatelaw-judge",
+          "caseworker-privatelaw-la",
           "caseworker-privatelaw-courtadmin",
           "caseworker-privatelaw-systemupdate"
         ],
@@ -17150,8 +17152,6 @@
       },
       {
         "UserRoles": [
-          "caseworker-privatelaw-judge",
-          "caseworker-privatelaw-la",
           "caseworker-privatelaw-solicitor",
           "citizen",
           "courtnav",

--- a/env.json
+++ b/env.json
@@ -5,9 +5,9 @@
     "aacUrl": "http://localhost:4454"
   },
   "preview": {
-    "cosUrl": "http://prl-ccd-definitions-pr-2727-java",
-    "ccdUrl": "http://prl-ccd-definitions-pr-2727-ccd-data-store-api",
-    "aacUrl": "http://prl-ccd-definitions-pr-2727-aac-manage-case-assignment"
+    "cosUrl": "http://prl-ccd-definitions-pr-2792-java",
+    "ccdUrl": "http://prl-ccd-definitions-pr-2792-ccd-data-store-api",
+    "aacUrl": "http://prl-ccd-definitions-pr-2792-aac-manage-case-assignment"
   },
   "environments": ["demo", "aat", "perftest", "ithc", "prod"],
   "baseUrls": {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[FPVTL-917](https://tools.hmcts.net/jira/browse/FPVTL-917)


### Change description ###
 - Add CRU perms for legal adviser and judges as they use manage orders too.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```