### PR TITLE
Increase definition store memory in preview

### DIFF
--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -471,7 +471,7 @@ aac-manage-case-assignment:
 
 prl-cos:
   java:
-    image: hmctspublic.azurecr.io/prl/cos:pr-3182
+    image: hmctspublic.azurecr.io/prl/cos:latest
     ingressHost: ${SERVICE_FQDN}
     imagePullPolicy: Always
     #Below settings are copied from prl-cos preview values, needs review.

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -126,6 +126,9 @@ ccd:
   ccd-definition-store-api:
     java:
       disableKeyVaults: true
+      devmemoryRequests: '1024Mi'
+      devmemoryLimits: '2048Mi'
+      devcpuRequests: '900m'
       imagePullPolicy: Always
       environment:
         DEFINITION_STORE_IDAM_KEY: ${DEFINITION_STORE_S2S_KEY}


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - As noted on another PR - the definition store in preview is sometimes OOMing, causing issues when coming to test any changes
 - This copies the configuration we were using over on the FPL service


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```