### PR TITLE
FPVTL-1093: DO-NOT-MERGE-Barrister removal when associated solicitor …

### DIFF
--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -472,7 +472,7 @@ aac-manage-case-assignment:
 
 prl-cos:
   java:
-    image: hmctspublic.azurecr.io/prl/cos:pr-3267
+    image: hmctspublic.azurecr.io/prl/cos:pr-3285
     ingressHost: ${SERVICE_FQDN}
     imagePullPolicy: Always
     #Below settings are copied from prl-cos preview values, needs review.


### PR DESCRIPTION
…is removed by caseworker



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-1093


### Change description ###
Barrister removal when associated solicitor is removed by caseworker


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```