### PR TITLE
FPVTL-1229 Bulkscan Quarantine perms fix

### DIFF
--- a/definitions/private-law/json/AuthorisationCaseField/Bulkscan/AuthorisationCaseField.json
+++ b/definitions/private-law/json/AuthorisationCaseField/Bulkscan/AuthorisationCaseField.json
@@ -87,13 +87,6 @@
     "LiveFrom": "27/08/2018",
     "CaseTypeID": "PRLAPPS",
     "CaseFieldID": "scannedDocuments",
-    "UserRole": "caseworker-privatelaw-solicitor",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "27/08/2018",
-    "CaseTypeID": "PRLAPPS",
-    "CaseFieldID": "scannedDocuments",
     "UserRole": "caseworker-privatelaw-cafcass",
     "CRUD": "R"
   },
@@ -102,13 +95,6 @@
     "CaseTypeID": "PRLAPPS",
     "CaseFieldID": "scannedDocuments",
     "UserRole": "caseworker-wa-task-configuration",
-    "CRUD": "R"
-  },
-  {
-    "LiveFrom": "27/08/2018",
-    "CaseTypeID": "PRLAPPS",
-    "CaseFieldID": "scannedDocuments",
-    "UserRole": "citizen",
     "CRUD": "R"
   },
   {


### PR DESCRIPTION
Resolves: FPVTL-1229[https://tools.hmcts.net/jira/browse/FPVTL-1229]
remove perms for solicitor/citizen to see pre-approved bulkscan documents in quarantine tab

