### PR TITLE
FPVTL-710: add about to start to update the statement of truth solicitor on application re-submission

### DIFF
--- a/definitions/private-law/json/CaseEvent/CaseEvent.json
+++ b/definitions/private-law/json/CaseEvent/CaseEvent.json
@@ -1212,6 +1212,7 @@
     "ShowSummary": "N",
     "ShowEventNotes": "N",
     "EventEnablingCondition": "caseTypeOfApplication=\"C100\"",
+    "CallBackURLAboutToStartEvent": "${CCD_DEF_COS_URL}/getSolicitorAndFeeDetails",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/resubmit-application",
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/update-task-list/updateTaskListOnly",
     "Publish": "True"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-710


### Change description ###
Add the about to submit callback to the "submit" event to allow the statement of truth solicitor to be updated on application resubmission


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```