### PR TITLE
Update Elasticsearch config

### DIFF
--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -234,6 +234,10 @@ ccd:
     nameOverride: ${SERVICE_NAME}-es
     clusterName: "es"
     replicas: 1
+    clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
+    esConfig:
+      elasticsearch.yml: |
+        discovery.type: single-node
 
   logstash:
     image: hmctsprod.azurecr.io/imported/elastic/logstash

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -239,10 +239,10 @@ ccd:
     esConfig:
       elasticsearch.yml: |
         discovery.type: single-node
-    extraEnvs:
-    - name: discovery.type
-      value: single-node
+  extraEnvs:
     - name: cluster.initial_master_nodes
+      value: ""
+    - name: discovery.seed_hosts
       value: ""
 
   logstash:

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -239,9 +239,6 @@ ccd:
     esConfig:
       elasticsearch.yml: |
         discovery.type: single-node
-    extraEnvs:
-    - name: discovery.seed_hosts
-      value: "[]"
 
   logstash:
     image: hmctsprod.azurecr.io/imported/elastic/logstash

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -234,7 +234,6 @@ ccd:
     nameOverride: ${SERVICE_NAME}-es
     clusterName: "es"
     replicas: 1
-    masterService: ""
     clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
     esConfig:
       elasticsearch.yml: |

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -239,11 +239,11 @@ ccd:
     esConfig:
       elasticsearch.yml: |
         discovery.type: single-node
-  extraEnvs:
-    - name: cluster.initial_master_nodes
-      value: ""
-    - name: discovery.seed_hosts
-      value: ""
+    extraEnvs:
+      - name: cluster.initial_master_nodes
+        value: ""
+      - name: discovery.seed_hosts
+        value: ""
 
   logstash:
     image: hmctsprod.azurecr.io/imported/elastic/logstash

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -234,10 +234,16 @@ ccd:
     nameOverride: ${SERVICE_NAME}-es
     clusterName: "es"
     replicas: 1
+    masterService: ""
     clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
     esConfig:
       elasticsearch.yml: |
         discovery.type: single-node
+    extraEnvs:
+    - name: discovery.type
+      value: single-node
+    - name: cluster.initial_master_nodes
+      value: ""
 
   logstash:
     image: hmctsprod.azurecr.io/imported/elastic/logstash

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -234,6 +234,7 @@ ccd:
     nameOverride: ${SERVICE_NAME}-es
     clusterName: "es"
     replicas: 1
+    masterService: ""
     clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
     esConfig:
       elasticsearch.yml: |

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -234,11 +234,7 @@ ccd:
     nameOverride: ${SERVICE_NAME}-es
     clusterName: "es"
     replicas: 1
-    masterService: ""
     clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
-    esConfig:
-      elasticsearch.yml: |
-        discovery.type: single-node
 
   logstash:
     image: hmctsprod.azurecr.io/imported/elastic/logstash

--- a/charts/prl-ccd-definitions/values.preview.template.yaml
+++ b/charts/prl-ccd-definitions/values.preview.template.yaml
@@ -240,10 +240,8 @@ ccd:
       elasticsearch.yml: |
         discovery.type: single-node
     extraEnvs:
-      - name: cluster.initial_master_nodes
-        value: ""
-      - name: discovery.seed_hosts
-        value: ""
+    - name: discovery.seed_hosts
+      value: "[]"
 
   logstash:
     image: hmctsprod.azurecr.io/imported/elastic/logstash


### PR DESCRIPTION
### Change description ###
Fix for ES message
`  "message": "This node is a fully-formed single-node cluster with cluster UUID [I0eB4bHLQk-alz8W_p0ctQ], but it is configured as if to discover other nodes and form a multi-node cluster via the [discovery.seed_hosts=[prl-ccd-definitions-pr-3484-es-master-headless]] setting. Fully-formed clusters do not attempt to discover other nodes, and nodes with different cluster UUIDs cannot belong to the same cluster. The cluster UUID persists across restarts and can only be changed by deleting the contents of the node's data path(s). Remove the discovery configuration to suppress this message. See [https://www.elastic.co/docs/deploy-manage/distributed-architecture/discovery-cluster-formation/modules-discovery-bootstrap-cluster?version=9.2#modules-discovery-bootstrap-cluster-joining] for more information.",`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```