### PR TITLE
FPVTL-2906: Ensure the ordering of C8s come after their res…

### DIFF
--- a/definitions/private-law/json/CaseTypeTab/ConfidentialTab/CaseTypeTab.json
+++ b/definitions/private-law/json/CaseTypeTab/ConfidentialTab/CaseTypeTab.json
@@ -17,8 +17,148 @@
     "TabID": "confidentialDetails",
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentConfidentialDetails",
+    "CaseFieldID": "c8Document",
     "TabFieldDisplayOrder": 2
+  },
+  {
+    "LiveFrom": "08/11/2021",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "c8WelshDocument",
+    "TabFieldDisplayOrder": 3
+  },
+  {
+    "LiveFrom": "08/11/2021",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "c8DraftDocument",
+    "TabFieldDisplayOrder": 4
+  },
+  {
+    "LiveFrom": "08/11/2021",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "c8WelshDraftDocument",
+    "TabFieldDisplayOrder": 5
+  },
+  {
+    "LiveFrom": "08/11/2021",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentConfidentialDetails",
+    "TabFieldDisplayOrder": 6
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentAc8",
+    "TabFieldDisplayOrder": 7
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentBc8",
+    "TabFieldDisplayOrder": 8
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentCc8",
+    "TabFieldDisplayOrder": 9
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentDc8",
+    "TabFieldDisplayOrder": 10
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentEc8",
+    "TabFieldDisplayOrder": 11
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentAc8Documents",
+    "TabFieldDisplayOrder": 12
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentBc8Documents",
+    "TabFieldDisplayOrder": 13
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentCc8Documents",
+    "TabFieldDisplayOrder": 14
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentDc8Documents",
+    "TabFieldDisplayOrder": 15
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
+    "CaseFieldID": "respondentEc8Documents",
+    "TabFieldDisplayOrder": 16
   },
   {
     "LiveFrom": "08/11/2021",
@@ -29,7 +169,7 @@
     "TabDisplayOrder": 4,
     "CaseFieldID": "childrenConfidentialDetails",
     "FieldShowCondition": "caseTypeOfApplication = \"C100\"",
-    "TabFieldDisplayOrder": 3
+    "TabFieldDisplayOrder": 17
   },
   {
     "LiveFrom": "08/11/2021",
@@ -40,7 +180,7 @@
     "TabDisplayOrder": 4,
     "CaseFieldID": "fl401ChildrenConfidentialDetails",
     "FieldShowCondition": "caseTypeOfApplication = \"FL401\"",
-    "TabFieldDisplayOrder": 4
+    "TabFieldDisplayOrder": 18
   },
   {
     "LiveFrom": "09/04/2026",
@@ -50,7 +190,17 @@
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
     "CaseFieldID": "otherPeopleConfidentialDetails",
-    "TabFieldDisplayOrder": 5
+    "TabFieldDisplayOrder": 19
+  },
+  {
+    "LiveFrom": "08/06/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabDisplayOrder": 4,
+    "TabLabel": "Confidential details",
+    "CaseFieldID": "otherPartyC8Documents",
+    "TabFieldDisplayOrder": 20
   },
   {
     "LiveFrom": "08/11/2021",
@@ -61,7 +211,7 @@
     "TabDisplayOrder": 4,
     "CaseFieldID": "caseTypeOfApplication",
     "FieldShowCondition": "caseTypeOfApplication = \"DO_NOT_SHOW\"",
-    "TabFieldDisplayOrder": 6
+    "TabFieldDisplayOrder": 21
   },
   {
     "LiveFrom": "08/11/2021",
@@ -71,7 +221,7 @@
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
     "CaseFieldID": "correspondenceForTabDisplay",
-    "TabFieldDisplayOrder": 7
+    "TabFieldDisplayOrder": 22
   },
   {
     "LiveFrom": "08/11/2021",
@@ -81,7 +231,7 @@
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
     "CaseFieldID": "otherDocumentsForTabDisplay",
-    "TabFieldDisplayOrder": 8
+    "TabFieldDisplayOrder": 23
   },
   {
     "LiveFrom": "08/11/2021",
@@ -91,97 +241,7 @@
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
     "CaseFieldID": "mainAppDocForTabDisplay",
-    "TabFieldDisplayOrder": 9
-  },
-  {
-    "LiveFrom": "08/11/2021",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "c8Document",
-    "TabFieldDisplayOrder": 10
-  },
-  {
-    "LiveFrom": "08/11/2021",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "c8WelshDocument",
-    "TabFieldDisplayOrder": 11
-  },
-  {
-    "LiveFrom": "08/11/2021",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "c8DraftDocument",
-    "TabFieldDisplayOrder": 12
-  },
-  {
-    "LiveFrom": "08/11/2021",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "c8WelshDraftDocument",
-    "TabFieldDisplayOrder": 13
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentAc8",
-    "TabFieldDisplayOrder": 14
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentBc8",
-    "TabFieldDisplayOrder": 15
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentCc8",
-    "TabFieldDisplayOrder": 16
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentDc8",
-    "TabFieldDisplayOrder": 17
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentEc8",
-    "TabFieldDisplayOrder": 18
+    "TabFieldDisplayOrder": 24
   },
   {
     "LiveFrom": "10/05/2023",
@@ -191,7 +251,7 @@
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
     "CaseFieldID": "legalProfUploadDocListConfTab",
-    "TabFieldDisplayOrder": 19
+    "TabFieldDisplayOrder": 25
   },
   {
     "LiveFrom": "10/05/2023",
@@ -201,66 +261,6 @@
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
     "CaseFieldID": "cafcassUploadDocListConfTab",
-    "TabFieldDisplayOrder": 20
-  },
-  {
-    "LiveFrom": "10/05/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "courtStaffUploadDocListConfTab",
-    "TabFieldDisplayOrder": 21
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentAc8Documents",
-    "TabFieldDisplayOrder": 22
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentBc8Documents",
-    "TabFieldDisplayOrder": 23
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentCc8Documents",
-    "TabFieldDisplayOrder": 24
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentDc8Documents",
-    "TabFieldDisplayOrder": 25
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabLabel": "Confidential details",
-    "TabDisplayOrder": 4,
-    "CaseFieldID": "respondentEc8Documents",
     "TabFieldDisplayOrder": 26
   },
   {
@@ -270,7 +270,7 @@
     "TabID": "confidentialDetails",
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
-    "CaseFieldID": "bulkScannedDocListConfTab",
+    "CaseFieldID": "courtStaffUploadDocListConfTab",
     "TabFieldDisplayOrder": 27
   },
   {
@@ -280,8 +280,18 @@
     "TabID": "confidentialDetails",
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
+    "CaseFieldID": "bulkScannedDocListConfTab",
+    "TabFieldDisplayOrder": 28
+  },
+  {
+    "LiveFrom": "10/05/2023",
+    "CaseTypeID": "PRLAPPS",
+    "Channel": "CaseWorker",
+    "TabID": "confidentialDetails",
+    "TabLabel": "Confidential details",
+    "TabDisplayOrder": 4,
     "CaseFieldID": "restrictedDocuments",
-    "TabFieldDisplayOrder": 28,
+    "TabFieldDisplayOrder": 29,
     "DisplayContextParameter": "#TABLE(categoryName, documentParty, documentUploadedDate)"
   },
   {
@@ -292,7 +302,7 @@
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
     "CaseFieldID": "confidentialDocuments",
-    "TabFieldDisplayOrder": 29,
+    "TabFieldDisplayOrder": 30,
     "DisplayContextParameter": "#TABLE(categoryName, documentParty, documentUploadedDate)"
   },
   {
@@ -303,16 +313,6 @@
     "TabLabel": "Confidential details",
     "TabDisplayOrder": 4,
     "CaseFieldID": "refugeDocuments",
-    "TabFieldDisplayOrder": 30
-  },
-  {
-    "LiveFrom": "08/06/2023",
-    "CaseTypeID": "PRLAPPS",
-    "Channel": "CaseWorker",
-    "TabID": "confidentialDetails",
-    "TabDisplayOrder": 4,
-    "TabLabel": "Confidential details",
-    "CaseFieldID": "otherPartyC8Documents",
     "TabFieldDisplayOrder": 31
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[FPVTL-2906](https://tools.hmcts.net/jira/browse/FPVTL-2906)
FPVTL-2202


### Change description ###
 - Rearrange the confidential information tab to have C8s (directly) after their respective conf data


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```