### PR TITLE
FPVTL-2482: use a Conditional Post Event State to avoid a Closed case going back to Hearing Outcome

### DIFF
--- a/definitions/private-law/json/CaseEvent/CaseEvent.json
+++ b/definitions/private-law/json/CaseEvent/CaseEvent.json
@@ -1567,7 +1567,7 @@
     "Name": "Decision Outcome",
     "Description": "HMC Case Update to Decision Outcome",
     "PreConditionState(s)": "*",
-    "PostConditionState": "DECISION_OUTCOME",
+    "PostConditionState": "DECISION_OUTCOME([STATE]!=\"ALL_FINAL_ORDERS_ISSUED\"):1;*",
     "CallBackURLAboutToSubmitEvent": "${CCD_DEF_COS_URL}/update-task-list/about-to-submit",
     "CallBackURLSubmittedEvent": "${CCD_DEF_COS_URL}/update-allTabs-after-hmc-case-state/submitted",
     "SecurityClassification": "Public",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPVTL-2482

### Change description ###
Use a Conditional Post Event State on the "hmcCaseUpdDecOutcome" event to avoid a Closed case going back to Hearing Outcome when hearings are cancelled after the case is already closed. On cancelling hearings, HMC calls PrL to update the case state, this should not happen when the case has already been closed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```