### PR TITLE
Pin wa-chart to 1.1.0

### DIFF
--- a/charts/prl-ccd-definitions/Chart.yaml
+++ b/charts/prl-ccd-definitions/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Private Law - CCD Definitions
 name: prl-ccd-definitions
-version: 0.0.56
+version: 0.0.57
 dependencies:
   - name: ccd
     version: 9.2.3
@@ -42,7 +42,7 @@ dependencies:
     alias: servicebusPrimary
     condition: servicebusPrimary.enabled
   - name: wa
-    version: ~1.1.0
+    version: 1.1.0
     repository: 'oci://hmctsprod.azurecr.io/helm'
     condition: wa.enabled
   - name: ccd-message-publisher


### PR DESCRIPTION
### Change description ###
Pin wa-chart to v1.1.0 because recent updates cause problems with work allocation in preview resulting in no tasks being generated


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```